### PR TITLE
Add customer personalization workflows to MVP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,87 +1,152 @@
 # Insuretech MVP (AI‑Native Insurer)
 
-This repository contains a **minimum viable product** for a fully digital insurer aligned to McKinsey’s **four-layer AI-native architecture**:
+This repository contains a **minimum viable product** for a fully digital insurer aligned to McKinsey’s four-layer AI-native architecture. You can clone it from GitHub and run the demo without writing any code.
 
-1) **User Experience layer:** separate portals (customer & employee) via simple placeholders, and an API for quotes, claims and chat.
-2) **Decision layer:** logistic regression risk, pricing algorithms, underwriting rules, fraud anomaly scoring; an **Orchestrator** composes decisions.
-3) **Infrastructure layer:** modular **agents** (marketing, customer360, claims, chatbot, data governance, compliance/fairness, fraud, observability, external data, learning feedback, infra modernization stub).
-4) **Data platform layer:** pydantic validation, simple SQLite store, and an **Observability Agent** exposing logs.
+## Architecture at a glance (plain-English tour)
 
-> ⚙️ Stack: FastAPI, scikit-learn, SQLAlchemy/SQLite, httpx, pydantic, pytest, Docker, GitHub Actions.
+1. **User experience layer** – A FastAPI service exposes easy-to-use HTTP endpoints (think of them as buttons you can press) for quotes, underwriting, claims, chat support, fraud scoring and system logs. Explore everything through the automatically generated docs at <http://127.0.0.1:8000/docs>.
+2. **Decision layer** – A logistic regression model estimates loss probability, the pricing agent calculates premiums, the underwriting agent produces approve/refer/reject outcomes, and compliance/fairness plus fraud scoring agents add guardrails.
+3. **Infrastructure layer** – Each capability lives in its own Python “agent” so it can be reused or swapped out. Implemented agents cover marketing, Customer 360, claims summarisation, chatbot, data governance, compliance, fraud detection, observability, learning feedback, external data lookups and infrastructure modernisation.
+4. **Data platform layer** – Pydantic validates every payload, SQLAlchemy/SQLite persist customer and log data, and the Observability Agent exposes the interaction history.
 
----
-
-## Quickstart (Local)
-
-```bash
-# 1) Python env
-python -m venv .venv && source .venv/bin/activate  # on Windows: .venv\Scripts\activate
-pip install -r backend/requirements.txt
-
-# 2) Run API
-uvicorn app.main:app --reload --port 8000 --app-dir backend
-
-# 3) Try it
-curl -X POST http://127.0.0.1:8000/quote -H "Content-Type: application/json" -d '{"customer_id":"c1","age":30,"vehicle_value":15000,"prior_claims":0,"credit_score":680,"gender":"F"}'
-```
-
-Open **http://127.0.0.1:8000/docs** for interactive API.
+> ⚙️ **Technology stack:** FastAPI, scikit-learn, SQLAlchemy/SQLite, httpx, pydantic, pytest, Docker and GitHub Actions.
 
 ---
 
-## Docker (Local)
+## Run the MVP locally (no prior coding knowledge needed)
+
+1. **Install Python 3.11 or newer.** On Windows or macOS download it from <https://www.python.org/downloads/> and tick the option that adds Python to PATH.
+2. **Open a terminal** (Command Prompt, PowerShell, macOS Terminal or Linux shell) and move into the folder where you cloned the repo:
+
+   ```bash
+   cd insuretech-mvp
+   ```
+
+3. **Create an isolated Python environment** so dependencies stay self-contained:
+
+   ```bash
+   python -m venv .venv
+   # Windows users: .venv\Scripts\activate
+   # macOS/Linux users:
+   source .venv/bin/activate
+   ```
+
+4. **Install the project requirements** (this may take a minute the first time):
+
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+
+5. **Start the API server** and leave it running while you try the demo:
+
+   ```bash
+   uvicorn app.main:app --reload --port 8000 --app-dir backend
+   ```
+
+6. **Interact with the endpoints:**
+   - Visit <http://127.0.0.1:8000/docs>. FastAPI serves a friendly web UI where you can click “Try it out” for every operation.
+   - Or use the terminal to request a quote:
+
+     ```bash
+     curl -X POST http://127.0.0.1:8000/quote \
+       -H "Content-Type: application/json" \
+       -d '{"customer_id":"c1","age":30,"vehicle_value":15000,"prior_claims":0,"credit_score":680,"gender":"F"}'
+     ```
+
+   - Explore `/underwrite`, `/claims`, `/chat`, `/fraud/score`, `/fx`, `/customers`, `/marketing/outreach` and `/logs` through the docs page to see how the agents collaborate.
+   - Tip: create a customer profile first so other agents can personalise responses:
+
+     ```bash
+     curl -X POST http://127.0.0.1:8000/customers \
+       -H "Content-Type: application/json" \
+       -d '{"customer_id":"cust-001","name":"Jamie Rivera","email":"jamie@example.com","phone":"+1-202-555-0100"}'
+     ```
+
+     Now call the marketing agent to generate outreach copy that uses the stored profile:
+
+     ```bash
+     curl -X POST http://127.0.0.1:8000/marketing/outreach \
+       -H "Content-Type: application/json" \
+       -d '{"customer_id":"cust-001","product":"AI Auto Protect"}'
+     ```
+
+7. **Stop the server** with `Ctrl+C` when you are finished. Deactivate the virtual environment using `deactivate`.
+
+---
+
+## Run with Docker (optional)
+
+Prefer containers? Install Docker Desktop and run:
 
 ```bash
 docker compose up --build
 ```
 
----
-
-## GitHub CI
-
-This repo ships a GitHub Actions workflow running lint/tests and building the Docker image. Add secrets (optional): `OPENAI_API_KEY` for Chatbot Agent, etc.
+The API will be available on <http://127.0.0.1:8000>. Use `Ctrl+C` to stop the stack.
 
 ---
 
-## Repo layout
+## Continuous verification
 
+Every push triggers the GitHub Actions workflow in `.github/workflows/ci.yml`, which installs dependencies, runs the automated tests and builds the Docker image. If you fork the repo you only need to push your commits. Optionally add secrets such as `OPENAI_API_KEY` to let the Chatbot Agent call a real LLM.
+
+To run the same test locally:
+
+```bash
+cd backend
+pytest
 ```
+
+---
+
+## What each agent does
+
+| Agent | Purpose |
+| --- | --- |
+| Marketing | Generates personalised outreach copy for prospects. |
+| Customer 360 | Stores and retrieves customer data in SQLite. |
+| Risk Model | Trains a tiny logistic regression model on synthetic data at startup and predicts probability of loss. |
+| Pricing | Computes base and risk-adjusted premiums. |
+| Underwriting | Applies business rules (risk thresholds, credit score, coverage limits) and outputs approval, referral or rejection reasons. |
+| Compliance & Fairness | Flags politically exposed persons and adds fairness review notes. |
+| Data Governance | Validates every payload using strict Pydantic schemas. |
+| Claims | Summarises claim descriptions and estimates complexity. |
+| Chatbot | Answers FAQ-style questions with a rule-based fallback (switches to an LLM when an OpenAI key is provided). |
+| Fraud Detection | Uses an Isolation Forest to score anomalous claim amounts. |
+| External Data | Retrieves FX rates from a public API with an offline fallback. |
+| Observability | Logs interactions for auditing; view them via `/logs`. |
+| Learning Feedback | Stores decision inputs/outputs to feed future model improvements. |
+| Infrastructure Modernisation | Demonstrates how legacy documents could be transformed into structured summaries. |
+
+Planned extensions (Retention, Product Recommendation, Advanced Fraud, Regulatory Compliance, Explainability, Market Intelligence, Talent Management, Climate Risk, Reinsurance) are sketched in the code as future enhancements.
+
+---
+
+## Repository layout
+
+```text
 backend/
   app/
-    main.py
-    models.py
-    config.py
-    storage.py
-    agents/
-      orchestrator.py
-      risk_model.py
-      pricing.py
-      underwriting.py
-      claims.py
-      chatbot.py
-      marketing.py
-      customer360.py
-      compliance.py
-      fraud.py
-      external_data.py
-      observability.py
-      data_gov.py
-      learning_feedback.py
-      infra_modernization.py
+    main.py               # FastAPI entrypoint wiring the agents together
+    models.py             # Pydantic request/response schemas
+    config.py             # Environment variables (DB URL, API keys)
+    storage.py            # SQLAlchemy ORM models and database bootstrap
+    agents/               # Individual functional components
   tests/
-    test_orchestrator.py
+    test_orchestrator.py  # Smoke test that the quote endpoint works end-to-end
   Dockerfile
   requirements.txt
-docker-compose.yml
-.github/workflows/ci.yml
+docker-compose.yml        # One-command local deployment
+.github/workflows/ci.yml  # Continuous integration pipeline
 ```
 
 ---
 
-## Next steps
+## Next steps (suggested roadmap)
 
 - Replace toy/synthetic training with real data pipelines.
-- Harden compliance (KYC/AML/PEP screening via providers).
+- Harden compliance (KYC/AML/PEP screening via external providers).
 - Add **Retention** and **Product Recommendation** agents.
-- Expand frontends (React/Vite apps) and auth (OAuth/OIDC, RBAC).
-- Move logs to OpenTelemetry + a real backend (ELK, Grafana, etc.).
+- Expand front-ends (React/Vite apps) and authentication (OAuth/OIDC, RBAC).
+- Stream logs to OpenTelemetry + an observability backend (ELK, Grafana, etc.).
+

--- a/backend/app/agents/customer360.py
+++ b/backend/app/agents/customer360.py
@@ -15,5 +15,6 @@ class Customer360Agent:
     def get(self, customer_id: str):
         with SessionLocal() as s:
             db = s.query(DBCustomer).filter_by(customer_id=customer_id).one_or_none()
-            if not db: return None
+            if not db:
+                return None
             return {"customer_id": db.customer_id, "name": db.name, "email": db.email, "phone": db.phone}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,21 @@ from .agents.chatbot import ChatbotAgent
 from .agents.fraud import FraudAgent
 from .agents.external_data import ExternalDataAgent
 from .agents.customer360 import Customer360Agent
-from .models import QuoteRequest, QuoteResponse, UnderwriteRequest, UnderwriteResponse, ClaimReport, ClaimResponse, ChatRequest, ChatResponse
+from .agents.marketing import MarketingAgent
+from .models import (
+    QuoteRequest,
+    QuoteResponse,
+    UnderwriteRequest,
+    UnderwriteResponse,
+    ClaimReport,
+    ClaimResponse,
+    ChatRequest,
+    ChatResponse,
+    CustomerPayload,
+    CustomerResponse,
+    MarketingRequest,
+    MarketingResponse,
+)
 
 app = FastAPI(title="Insuretech MVP API", version="0.1.0")
 app.add_middleware(
@@ -26,6 +40,9 @@ def get_obs():
 
 def get_orchestrator(obs=Depends(get_obs)):
     return DecisionOrchestrator(obs)
+
+def get_customer360():
+    return Customer360Agent()
 
 @app.get("/health")
 def health():
@@ -62,7 +79,40 @@ def logs(obs: ObservabilityAgent = Depends(get_obs), limit: int = 50):
 async def fx(base: str = "USD"):
     return await ExternalDataAgent().get_fx(base)
 
-@app.post("/customers/upsert")
-def upsert_customer(customer_id: str, name: str, email: str, phone: str | None = None):
-    Customer360Agent().upsert(customer_id, name, email, phone)
-    return {"ok": True}
+@app.post("/customers", response_model=CustomerResponse)
+def upsert_customer(
+    payload: CustomerPayload,
+    c360: Customer360Agent = Depends(get_customer360),
+    obs: ObservabilityAgent = Depends(get_obs),
+):
+    c360.upsert(payload.customer_id, payload.name, payload.email, payload.phone)
+    obs.log("customer360", "upsert", payload.model_dump())
+    stored = c360.get(payload.customer_id)
+    if not stored:
+        raise HTTPException(status_code=500, detail="Customer record not stored")
+    return stored
+
+
+@app.get("/customers/{customer_id}", response_model=CustomerResponse)
+def get_customer(customer_id: str, c360: Customer360Agent = Depends(get_customer360)):
+    record = c360.get(customer_id)
+    if not record:
+        raise HTTPException(status_code=404, detail="Customer not found")
+    return record
+
+
+@app.post("/marketing/outreach", response_model=MarketingResponse)
+def marketing_outreach(
+    payload: MarketingRequest,
+    c360: Customer360Agent = Depends(get_customer360),
+    obs: ObservabilityAgent = Depends(get_obs),
+):
+    customer = c360.get(payload.customer_id)
+    name = customer["name"] if customer else payload.customer_id
+    message = MarketingAgent().craft_outreach(name, payload.product)
+    obs.log(
+        "marketing",
+        "outreach_generated",
+        {"customer_id": payload.customer_id, "product": payload.product, "has_profile": bool(customer)},
+    )
+    return {"message": message}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -47,8 +47,28 @@ class LogRecord(BaseModel):
     action: str
     payload: dict
 
-class Customer(BaseModel):
+class CustomerPayload(BaseModel):
     customer_id: str
     name: str
     email: str
     phone: str | None = None
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, value: str) -> str:
+        if "@" not in value or value.startswith("@") or value.endswith("@"):
+            raise ValueError("Email must contain a username and domain")
+        return value.lower()
+
+
+class CustomerResponse(CustomerPayload):
+    pass
+
+
+class MarketingRequest(BaseModel):
+    customer_id: str
+    product: str
+
+
+class MarketingResponse(BaseModel):
+    message: str

--- a/backend/tests/test_orchestrator.py
+++ b/backend/tests/test_orchestrator.py
@@ -1,3 +1,19 @@
+"""High level smoke tests for the public FastAPI endpoints.
+
+The repository is organised so that the application code lives in ``backend/app``.
+When pytest executes from the ``backend`` directory the package is importable as
+``app``. Some environments, however, run pytest from the repository root or
+without automatically adding the current working directory to ``sys.path``. To
+ensure the tests always run (for example on GitHub Actions) we explicitly append
+the parent directory of this test file to ``sys.path`` before importing the
+FastAPI application.
+"""
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from fastapi.testclient import TestClient
 from app.main import app
 
@@ -18,3 +34,28 @@ def test_quote():
     assert "probability_of_loss" in data
     assert "final_premium" in data
     assert data["decision"] in {"auto_approve","refer","reject"}
+
+
+def test_customer_and_marketing_flow():
+    customer_payload = {
+        "customer_id": "cust-123",
+        "name": "Alex Johnson",
+        "email": "alex@example.com",
+        "phone": "+1234567890",
+    }
+    r = client.post("/customers", json=customer_payload)
+    assert r.status_code == 200
+    stored = r.json()
+    assert stored["customer_id"] == customer_payload["customer_id"]
+    assert stored["email"] == customer_payload["email"]
+
+    r = client.get(f"/customers/{customer_payload['customer_id']}")
+    assert r.status_code == 200
+    fetched = r.json()
+    assert fetched == stored
+
+    marketing_payload = {"customer_id": customer_payload["customer_id"], "product": "Smart Auto"}
+    r = client.post("/marketing/outreach", json=marketing_payload)
+    assert r.status_code == 200
+    message = r.json()["message"]
+    assert customer_payload["name"] in message


### PR DESCRIPTION
## Summary
- add JSON-based customer profile endpoints and a marketing outreach endpoint with observability logging
- introduce dedicated Pydantic models for customer and marketing payloads, including lightweight email validation
- document the personalised customer+marketing demo flow so newcomers can exercise the agents end-to-end

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e54233de708325a4cda03167575831